### PR TITLE
Add a module that allows to measure compression for websockets

### DIFF
--- a/src/cowboy_compression_monitor.erl
+++ b/src/cowboy_compression_monitor.erl
@@ -1,0 +1,13 @@
+-module(cowboy_compression_monitor).
+-export([report_deflate/2]).
+-export([report_inflate/2]).
+
+%% Called when we compress data
+-spec report_deflate(Uncompressed :: iolist(), Compressed :: iolist()) -> ok.
+report_deflate(_Uncompressed, _Compressed) ->
+    ok.
+
+%% Called when we decompress data
+-spec report_inflate(Uncompressed :: iolist(), Compressed :: iolist()) -> ok.
+report_inflate(_Uncompressed, _Compressed) ->
+    ok.


### PR DESCRIPTION
This module name can be configured, so we would implement one for exometer (i.e. for mongooseim)