### PR TITLE
Allow pause websocket

### DIFF
--- a/src/cowboy_websocket.erl
+++ b/src/cowboy_websocket.erl
@@ -865,7 +865,7 @@ maybe_activate(Req, HandlerState, State = #state{socket=Socket, transport=Transp
 
 -spec activate_socket(Req) -> Req when Req::cowboy_req:req().
 activate_socket(Req) ->
-	{WasActive, Req2} = cowboy_req:meta(active_socket, Req, true),
+	{WasActive, Req2} = cowboy_req:meta(active_socket, Req, false),
 	case WasActive of
 		true ->
 			Req2;


### PR DESCRIPTION
Add cowboy_websocket:activate_socket/1 and deactivate_socket/1 functions, that are called by a client.
Implementation limitations:
- shapers are on the handler side (in mod_websockets). So, shapers pause is triggered only after data is passed to mod_websockets. 
- Regular websocket implementation passes into mod_websocket each frame, i.e. around 1460 bytes. It makes the implementation properly working.
- But compressed websocket can actually pass more data into mod_websockets at once, before shapers are checked and pause is triggered.
